### PR TITLE
Add important environment variables to the .env.example file in the remix-minimal folder

### DIFF
--- a/README-host-in-light-module.md
+++ b/README-host-in-light-module.md
@@ -10,7 +10,7 @@ Build and deploy the SPA to make it available for editing.
 
 Go to `/spa/remix-minimal` on the terminal and run `npm install`.
 
-See the `.env` files for important configurations.
+See the `.env.example` files for important configurations.
 
 Start Magnolia up with `mgnl start`.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Build and deploy the SPA to make it available for editing.
 
 ### Remix
 
-Go to `/spa/remix-minimal` on the terminal and run `npm install`, and then `npm run dev`.
+Go to `/spa/remix-minimal` on the terminal and run `npm install`, specify important environment variables (see `/spa/remix-minimal/.env.example`), and then `npm run dev`.
 
 It will start start the Remix server.
 

--- a/spa/remix-minimal/.env.example
+++ b/spa/remix-minimal/.env.example
@@ -1,0 +1,2 @@
+MGNL_HOST=http://localhost:8080/magnoliaAuthor
+MGNL_LANGUAGES=en


### PR DESCRIPTION
Remix environment variables are missed in the demo and lead to the issue :
```
TypeError: Only absolute URLs are supported
    at getNodeRequestOptions (/Users/oleksii/webcraft/minimal-headless-spa-demos/spa/remix-minimal/node_modules/node-fetch/lib/index.js:1327:9)
    at /Users/oleksii/webcraft/minimal-headless-spa-demos/spa/remix-minimal/node_modules/node-fetch/lib/index.js:1440:19
    at new Promise (<anonymous>)
    at Object.fetch [as default] (/Users/oleksii/webcraft/minimal-headless-spa-demos/spa/remix-minimal/node_modules/node-fetch/lib/index.js:1437:9)
    at fetch (/Users/oleksii/webcraft/minimal-headless-spa-demos/spa/remix-minimal/node_modules/@remix-run/node/fetch.js:136:39)
    at loader3 (/Users/oleksii/webcraft/minimal-headless-spa-demos/spa/remix-minimal/app/routes/index.tsx:85:26)
    at Object.callRouteLoader (/Users/oleksii/webcraft/minimal-headless-spa-demos/spa/remix-minimal/node_modules/@remix-run/server-runtime/data.js:77:20)
    at /Users/oleksii/webcraft/minimal-headless-spa-demos/spa/remix-minimal/node_modules/@remix-run/server-runtime/server.js:259:113
    at Array.map (<anonymous>)
    at handleDocumentRequest (/Users/oleksii/webcraft/minimal-headless-spa-demos/spa/remix-minimal/node_modules/@remix-run/server-runtime/server.js:259:67)
```

It happens because `spa/remix-minimal/.env` file is listed in `.gitignore` and is not committed, though in README we have a mention to look into that file.